### PR TITLE
Refactor APIs to give dumper a reference to the builder

### DIFF
--- a/src/BuilderInterface.php
+++ b/src/BuilderInterface.php
@@ -3,10 +3,11 @@
 namespace PackageGenerator;
 
 use Gitonomy\Git\Reference;
+use Gitonomy\Git\Repository;
 
 interface BuilderInterface {
 
-  public function __construct(array $composerJson, array $composerLock, Reference $gitObject);
+  public function __construct(array $composerJson, array $composerLock, Reference $gitObject, array $config, Repository $metapackage_repository);
 
   /**
    * @return string

--- a/src/Commands/RoboFile.php
+++ b/src/Commands/RoboFile.php
@@ -18,6 +18,7 @@ use Symfony\Component\Yaml\Yaml;
  */
 class RoboFile extends Tasks
 {
+  protected $clonedList = [];
 
   /**
    * @return \Robo\Collection\CollectionBuilder
@@ -41,12 +42,18 @@ class RoboFile extends Tasks
     $source = 'tmp/' . hash('sha256', $config['source']);
     $target = 'tmp/' . hash('sha256', $config['target']);
 
-    if (!file_exists($source)) {
+    $collection->progressMessage("Source is $source");
+
+    if (!file_exists($source) && !array_key_exists($source, $this->clonedList)) {
+      $this->clonedList[$source] = true;
       $collection->taskGitStack()
         ->cloneRepo($config['source'], $source);
     }
 
-    if (!file_exists($target)) {
+    $collection->progressMessage("Target is $target");
+
+    if (!file_exists($target) && !array_key_exists($target, $this->clonedList)) {
+      $this->clonedList[$target] = true;
       $collection->taskGitStack()
         ->cloneRepo($config['target'], $target);
     }
@@ -118,7 +125,7 @@ class RoboFile extends Tasks
       }
     });
 
-    $collection->progressMessage($target);
+    $collection->progressMessage("Done with $target");
 
     $collection->taskGitStack()
       ->dir($target)

--- a/src/Commands/RoboFile.php
+++ b/src/Commands/RoboFile.php
@@ -112,8 +112,8 @@ class RoboFile extends Tasks
         $metapackage_repository->run('config', ['user.email', $config['git']['author']['email']]);
 
         /** @var BuilderInterface $builder */
-        $builder = new $config['builder']($composerJsonData, $composerLockData, $ref);
-        $dump = new Dumper($ref, $builder->getPackage(), $metapackage_repository, $builder->getCommitMessage());
+        $builder = new $config['builder']($composerJsonData, $composerLockData, $ref, $config, $metapackage_repository);
+        $dump = new Dumper($ref, $builder, $metapackage_repository);
         $dump->write();
       }
     });

--- a/src/Dumper.php
+++ b/src/Dumper.php
@@ -13,8 +13,6 @@ class Dumper {
    */
   protected $reference;
 
-  protected $package;
-
   protected $repository;
 
   /**
@@ -31,7 +29,10 @@ class Dumper {
 
   protected $commitMessage;
 
-  public function __construct(\Gitonomy\Git\Reference $reference, array $package, Repository $repository, $commitMessage) {
+  protected $builder;
+
+  public function __construct(\Gitonomy\Git\Reference $reference, BuilderInterface $builder, Repository $repository) {
+
     if ($reference instanceof Tag || $reference instanceof Branch) {
       $this->reference = $reference;
     }
@@ -39,9 +40,9 @@ class Dumper {
       throw new \InvalidArgumentException('$ref is not a tag or branch.');
     }
 
-    $this->package = $package;
+    $this->builder = $builder;
     $this->repository = $repository;
-    $this->commitMessage = $commitMessage;
+    $this->commitMessage = $builder->getCommitMessage();
   }
 
   protected function getBranch(\Gitonomy\Git\Reference $reference) {
@@ -79,7 +80,9 @@ class Dumper {
       return;
     }
 
-    file_put_contents($this->repository->getPath() . '/composer.json', json_encode($this->package, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    $package = $this->builder->getPackage();
+
+    file_put_contents($this->repository->getPath() . '/composer.json', json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     $this->repository->run('add', ['composer.json']);
 
     if (isset($this->tag)) {


### PR DESCRIPTION
This adds a reference to the config and also to the repository being created to the builder. This allows this project to be used to create derivative projects that are more than just metapackages, i.e. because they contain copies of certain files from the source repository.

This is a breaking change that requires modification to all clients of this package. See other PRs that reference this one (future) for full explanation. You will not necessarily want to take this change.